### PR TITLE
Sr. Pago, map InvalidParamException to config_error

### DIFF
--- a/src/Gateways/SrPago/SrPagoGateway.php
+++ b/src/Gateways/SrPago/SrPagoGateway.php
@@ -79,7 +79,7 @@ class SrPagoGateway extends AbstractGateway
      * @var array
      */
     protected $errorCodeMap = [
-        'InvalidParamException'       => 'invalid_param',        // Malformed JSON, invalid fields, not required fields
+        'InvalidParamException'       => 'config_error',        // Malformed JSON, invalid fields, not required fields
         'InvalidEncryptionException'  => 'invalid_encryption',   // Incorrect data encryption
         'PaymentFilterException'      => 'processing_error',     // System detected supicious elements
         'SuspectedFraudException'     => 'suspected_fraud',      // System detected transaction as fraud


### PR DESCRIPTION
En el mapa de códigos de error del Gateway de Sr.Pago, se hace el cambio para que `InvalidParamException` corresponda a `config_error`.