### PR TITLE
[PPE] Allow to set no shipping on charges

### DIFF
--- a/src/Gateways/PaypalExpress/Charges.php
+++ b/src/Gateways/PaypalExpress/Charges.php
@@ -187,7 +187,15 @@ class Charges extends AbstractApi implements ChargeInterface
      */
     protected function addShippingAddress(array $params, array $options)
     {
-        if ($address = Arr::get($options, 'shipping_address')) {
+        if (!array_key_exists('shipping_address', $options)) {
+            return $params;
+        }
+
+        $address = $options['shipping_address'];
+
+        if (!$address) {
+            $params['NOSHIPPING'] = 1;
+        } elseif (is_array($address)) {
             $params['ADDROVERRIDE'] = 1;
             $params['PAYMENTREQUEST_0_SHIPPINGAMT'] = $this->gateway->amount(Arr::get($address, 'price', 0));
             $params['PAYMENTREQUEST_0_SHIPTOSTREET'] = Arr::get($address, 'address1');

--- a/src/Gateways/PaypalExpress/PaypalExpressGateway.php
+++ b/src/Gateways/PaypalExpress/PaypalExpressGateway.php
@@ -144,8 +144,6 @@ class PaypalExpressGateway extends AbstractGateway
         $params['PWD'] = $this->config['password'];
         $params['SIGNATURE'] = $this->config['signature'];
 
-        $success = false;
-
         $request = [
             'exceptions'      => false,
             'timeout'         => '60',
@@ -171,20 +169,19 @@ class PaypalExpressGateway extends AbstractGateway
             $response = $this->responseError((string) $rawResponse->getBody());
         }
 
-        return $this->respond($success, $params, $response, $options);
+        return $this->respond($params, $response, $options);
     }
 
     /**
      * Respond with an array of responses or a single response.
      *
-     * @param bool  $success
      * @param array $request
      * @param array $response
      * @param array $options
      *
      * @return array|\Shoperti\PayMe\Contracts\ResponseInterface
      */
-    protected function respond($success, $request, $response, $options)
+    protected function respond($request, $response, $options)
     {
         $success = isset($response['ACK']) && in_array($response['ACK'], ['Success', 'SuccessWithWarning']);
 

--- a/src/Gateways/PaypalPlus/Charges.php
+++ b/src/Gateways/PaypalPlus/Charges.php
@@ -61,7 +61,8 @@ class Charges extends AbstractApi implements ChargeInterface
         return $this->gateway->commit(
             'post',
             $this->gateway->buildUrlFromString('payments/payment'),
-            $payload, $options
+            $payload,
+            $options
         );
     }
 

--- a/src/Gateways/SrPago/Charges.php
+++ b/src/Gateways/SrPago/Charges.php
@@ -159,10 +159,10 @@ class Charges extends AbstractApi implements ChargeInterface
                     'memberLoggedIn'        => Arr::get($options, 'logged_id', 'No'),
                     'memberId'              => Arr::get($options, 'user_id'),
                     'memberFullName'        => trim(
-                                                Arr::get($options, 'first_name', '').' '.
+                        Arr::get($options, 'first_name', '').' '.
                                                 (empty($options['middle_name']) ? '' : Arr::get($options, 'middle_name').' ').
                                                 Arr::get($options, 'last_name', '')
-                                            ),
+                    ),
                     'memberFirstName'       => Arr::get($options, 'first_name', ''),
                     'memberMiddleName'      => Arr::get($options, 'middle_name', ''),
                     'memberLastName'        => Arr::get($options, 'last_name', ''),

--- a/src/Gateways/SrPago/Customers.php
+++ b/src/Gateways/SrPago/Customers.php
@@ -70,10 +70,10 @@ class Customers extends AbstractApi implements CustomerInterface
         ];
 
         return $this->gateway->commit(
-                'post',
-                $this->gateway->buildUrlFromString('customer/'.$customer.'/cards'),
-                $params
-            );
+            'post',
+            $this->gateway->buildUrlFromString('customer/'.$customer.'/cards'),
+            $params
+        );
     }
 
     /**

--- a/src/Gateways/SrPago/SrPagoGateway.php
+++ b/src/Gateways/SrPago/SrPagoGateway.php
@@ -116,7 +116,8 @@ class SrPagoGateway extends AbstractGateway
             $parsed = $this->parseResponse($response->getBody());
 
             // Be aware that this gateway validation error responses may be an HTTP 500 code.
-            return $retries < 3 && ($exception instanceof ConnectException ||
+            return $retries < 3 && (
+                $exception instanceof ConnectException ||
                 (
                     $response->getStatusCode() >= 500 &&
                     isset($parsed['error']['code']) &&


### PR DESCRIPTION
Send
```php
$options['shipping_address'] = null;

charges()->create($_1, $_2, $options)
```
to indicate no shipping